### PR TITLE
Gulp：BrowserSyncとSassのコンパイルを同時に行う

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ const browserSync = require("browser-sync");
 
 
 // style.scssの監視タスクを作成する
-gulp.task("default", function() {
+gulp.task("sass", function() {
   // ★ style.scssファイルを監視
   return gulp.watch("css/style.scss", function() {
     // style.scssの更新があった場合の処理
@@ -55,7 +55,12 @@ gulp.task("browserSyncTask", function() {
   });
 
   // srcフォルダ以下のファイルを監視
-  gulp.watch("./**", function() {
+  gulp.watch("./**", function(cb) {
     browserSync.reload(); // ファイルに変更があれば同期しているブラウザをリロード
+    // browserSyncのreload()が終わったことを通知する
+    cb();
   });
 });
+
+// sassのタスクとbrowserSyncTaskを同時に実行する
+gulp.task("default",  gulp.parallel("sass", "browserSyncTask"));


### PR DESCRIPTION
Twitterでやりとりしていた、BrowserSyncとSassのコンパイルを同時に行う手順です。

# 変更箇所

変更点は2箇所です。

1. `// srcフォルダ以下のファイルを監視` の箇所で、 `cb` の設定を追加しました。これは、「browserSync.reload(); の処理が終わったら、それをGulpに知らせて下さい」という設定です。 Gulp4では、このようにタスクの終了の通知が必要になりました。 Sassのタスクでは `return` がその役目を担っています。

2. 「sassのタスクとbrowserSyncTaskを同時に実行する」の箇所で、parallels() という処理を使いました。これは、Gulpのタスクを同時（並列）に行うための処理です。詳しくは次の記事を参照ください。
https://qiita.com/tonkotsuboy_com/items/9ab83fe0f25cf0b010f3


# プルリクエストについて

もしプルリクエストに慣れていらっしゃなければ、次の点を注意ください。

- このプルリクエストをマージすると、倉嶋さまのmasterブランチに変更内容が取り込まれます。
- もしこの内容が倉嶋さまの作業内容に適していないようであれば、マージはしないという選択肢もあります。


---

以上、不明な点などありましたら、お気軽に質問くださいませ。